### PR TITLE
可読性のためのいくつかの細かなリファクタリングをする

### DIFF
--- a/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
@@ -38,16 +38,18 @@ class RepositoryDetailViewController: UIViewController {
     }
 
     func setupAvatarImage(repository: [String: Any]) {
-        if let owner = repository["owner"] as? [String: Any] {
-            if let avatarURL = owner["avatar_url"] as? String {
-                URLSession.shared.dataTask(with: URL(string: avatarURL)!) { (data, res, err) in
-                    let image = UIImage(data: data!)!
-                    DispatchQueue.main.async {
-                        self.avatarImageView.image = image
-                    }
-                }.resume()
-            }
+        guard let owner = repository["owner"] as? [String: Any],
+            let avatarURL = owner["avatar_url"] as? String
+        else {
+            return
         }
+
+        URLSession.shared.dataTask(with: URL(string: avatarURL)!) { (data, res, err) in
+            let image = UIImage(data: data!)!
+            DispatchQueue.main.async {
+                self.avatarImageView.image = image
+            }
+        }.resume()
     }
 
 }

--- a/iOSEngineerCodeCheck/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/RepositorySearchViewController.swift
@@ -67,21 +67,22 @@ extension RepositorySearchViewController: UISearchBarDelegate {
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         let query = searchBar.text!
+        guard !query.isEmpty else { return }
 
-        if query.count != 0 {
-            let url = "https://api.github.com/search/repositories?q=\(query)"
-            task = URLSession.shared.dataTask(with: URL(string: url)!) { (data, res, err) in
-                if let obj = try! JSONSerialization.jsonObject(with: data!) as? [String: Any] {
-                    if let items = obj["items"] as? [[String: Any]] {
-                        self.repositories = items
-                        DispatchQueue.main.async {
-                            self.tableView.reloadData()
-                        }
-                    }
-                }
+        let url = "https://api.github.com/search/repositories?q=\(query)"
+        task = URLSession.shared.dataTask(with: URL(string: url)!) { (data, res, err) in
+            guard let obj = try! JSONSerialization.jsonObject(with: data!) as? [String: Any],
+                let items = obj["items"] as? [[String: Any]]
+            else {
+                return
             }
-            task?.resume()
+
+            self.repositories = items
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
         }
+        task?.resume()
     }
 
 }


### PR DESCRIPTION
close #1 

コードの可読性を落としていると感じたいくつかの点を修正するためのリファクタリングをしています。細かいものが多く、好みの問題の修正も含まれているかもしれません。これで自分がぱっと思いつく範囲の可読性の向上は行ったので #1 は閉じます！

 各修正の内容は以下です。

- ローカル変数で十分な変数がプロパティになっていたり、private で十分なプロパティが public になっていたりで、変数の使われ方の可能性が広いことでコードが読みにくくなっていたと思います。変数の使われる範囲を狭めることで、この変数はここでしか使われないんだなと安心してコードが読め、かつ使われ方も分かりやすくなります。その観点で以下２つの修正をしています
  - https://github.com/maiyama18/ios-engineer-codecheck/commit/0e01aefc952247a7677cd4effe10bf0675eacaa5
  - https://github.com/maiyama18/ios-engineer-codecheck/commit/8a61120256a80a35a19680d40079eff0eb9e7139
- レポジトリ詳細画面の `getImage` メソッドは名前からは「画像を取得する」役割を想像しますが、実際には「画像を表示する」ところまで行っていたり、全く関係ない「タイトルの設定」もしています。 https://github.com/maiyama18/ios-engineer-codecheck/commit/093e9594cb9f60b0244d6e85c65fdf38b8e553a4 で名前と役割を合わせました
- レポジトリ検索画面の UISearchBarDelegate への準拠部分を extension に切り出しました。これは好みの範疇でどちらでも良いかなと思いますが、個人的には protocol への準拠は分けた方が分かりやすいので修正してみています https://github.com/maiyama18/ios-engineer-codecheck/commit/ae3828fe965c96b44bb9cc5a15b2614ee3ddae33
- if 文のネストが深くなっている箇所がありました。それだけならとくに問題ないですが、今回の場合は if 文のいちばん内側が正常系で、そういう場合は guard で異常系を早期リターンして正常系のネストを浅くした方が読みやすいと思うので https://github.com/maiyama18/ios-engineer-codecheck/commit/9602b972d13c784e074ca714af9a540ef33544fe でそのようにしました