### PR TITLE
レポジトリ詳細画面のレイアウトエラー修正のために制約を追加する

### DIFF
--- a/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
+++ b/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
@@ -129,6 +129,7 @@
                             <constraint firstItem="4q1-pG-WSB" firstAttribute="top" secondItem="Iim-eb-8Ad" secondAttribute="bottom" constant="28" id="G2L-KM-330"/>
                             <constraint firstItem="4q1-pG-WSB" firstAttribute="centerX" secondItem="Iim-eb-8Ad" secondAttribute="centerX" id="Ght-Nb-HEu"/>
                             <constraint firstItem="srK-fe-i1b" firstAttribute="trailing" secondItem="Iim-eb-8Ad" secondAttribute="trailing" constant="20" id="IgU-EN-fM3"/>
+                            <constraint firstItem="oOe-O2-3RS" firstAttribute="top" secondItem="4q1-pG-WSB" secondAttribute="bottom" constant="22.5" id="Xui-pD-IcW"/>
                             <constraint firstItem="oOe-O2-3RS" firstAttribute="width" secondItem="Iim-eb-8Ad" secondAttribute="width" id="dPu-j0-Myp"/>
                             <constraint firstItem="oOe-O2-3RS" firstAttribute="centerX" secondItem="4q1-pG-WSB" secondAttribute="centerX" id="kVV-YK-ePr"/>
                             <constraint firstItem="Iim-eb-8Ad" firstAttribute="centerY" secondItem="srK-fe-i1b" secondAttribute="centerY" multiplier="0.7" id="ruB-l0-4VM"/>


### PR DESCRIPTION
ref: #3 

star / fork の数を表示するラベルが並んだ StackView について、y 方向の制約がなくエラーになっていた＆実際のレイアウトもおかしかったので制約を追加しました。

| before | after |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 - 2022-03-14 at 22 12 21](https://user-images.githubusercontent.com/22269397/158179601-821866b0-4a95-4c69-bd17-9ef6975b6c8a.png) | ![Simulator Screen Shot - iPhone 13 - 2022-03-14 at 22 14 20](https://user-images.githubusercontent.com/22269397/158179627-f50bcd76-3373-4ae2-94fe-00304efb6091.png) |