### PR TITLE
レスポンスフィールド名の typo により watcher 数が常に 0 で表示される問題を修正する

### DIFF
--- a/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
@@ -31,7 +31,7 @@ class RepositoryDetailViewController: UIViewController {
         titleLabel.text = repository["full_name"] as? String
         languageLabel.text = "Written in \(repository["language"] as? String ?? "")"
         starsLabel.text = "\(repository["stargazers_count"] as? Int ?? 0) stars"
-        watchersLabel.text = "\(repository["wachers_count"] as? Int ?? 0) watchers"
+        watchersLabel.text = "\(repository["watchers_count"] as? Int ?? 0) watchers"
         forksLabel.text = "\(repository["forks_count"] as? Int ?? 0) forks"
         openIssuesLabel.text = "\(repository["open_issues_count"] as? Int ?? 0) open issues"
         setupAvatarImage(repository: repository)


### PR DESCRIPTION
ref: #3 

https://docs.github.com/ja/rest/reference/search#search-repositories のレスポンス例のように、レポジトリの watcher 数のフィールド名は `watchers_count` だが、`wachers_count` と typo していたため常に watcher 数が 0 で表示されていた。この typo を修正しました。

ただし、この不具合の根本原因は

- レスポンスを `struct` ではなく dictionary として扱い、フィールドに文字列を使ってアクセスしていること
- GitHub API のレスポンス構造の知識が ViewController にまで散らばっていること
- パースのテストがないこと

などであり、今回は typo でそれが表出しているだけにすぎないと思っています。これらの問題は #4 #6 あたりで修正する予定です。

| before | after |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 - 2022-03-14 at 22 14 20](https://user-images.githubusercontent.com/22269397/158181262-3aa4a16a-f63d-45bd-b2b4-e16171e124e7.png) | ![Simulator Screen Shot - iPhone 13 - 2022-03-14 at 22 26 40](https://user-images.githubusercontent.com/22269397/158181289-f5154220-1139-4abd-8994-9d334fa75c06.png) |