### PR TITLE
利用言語が null のレポジトリでは言語欄を空にする

### DIFF
--- a/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
@@ -29,7 +29,11 @@ class RepositoryDetailViewController: UIViewController {
         let repository = searchVC.repositories[searchVC.selectedIndex]
 
         titleLabel.text = repository["full_name"] as? String
-        languageLabel.text = "Written in \(repository["language"] as? String ?? "")"
+        if let language = repository["language"] as? String {
+            languageLabel.text = "Written in \(language)"
+        } else {
+            languageLabel.text = nil
+        }
         starsLabel.text = "\(repository["stargazers_count"] as? Int ?? 0) stars"
         watchersLabel.text = "\(repository["watchers_count"] as? Int ?? 0) watchers"
         forksLabel.text = "\(repository["forks_count"] as? Int ?? 0) forks"


### PR DESCRIPTION
ref: #3 

いくつかのレポジトリではレスポンスの language フィールドが null で返ってきます。このような場合に元々のコードだと、レポジトリ詳細画面の languageLabel には `Written in` とだけ表示され、意味が取れない状態になっていました。どう修正するのが良いかは悩ましいですが、この PR では language フィールドが null なら言語欄は空にするようにします。

| before | after |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 - 2022-03-14 at 22 38 29](https://user-images.githubusercontent.com/22269397/158184984-055e6b83-2b6d-4966-a881-e85628c11245.png) | ![Simulator Screen Shot - iPhone 13 - 2022-03-14 at 22 42 31](https://user-images.githubusercontent.com/22269397/158185012-a84d696f-b739-4a7f-a009-c39c18595234.png) |