### PR TITLE
検索を実行したらキーボードを閉じる

### DIFF
--- a/iOSEngineerCodeCheck/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/RepositorySearchViewController.swift
@@ -77,6 +77,8 @@ extension RepositorySearchViewController: UISearchBarDelegate {
         let query = searchBar.text!
         guard !query.isEmpty else { return }
 
+        searchBar.resignFirstResponder()
+
         let url = "https://api.github.com/search/repositories?q=\(query)"
         task = URLSession.shared.dataTask(with: URL(string: url)!) { (data, res, err) in
             guard let obj = try! JSONSerialization.jsonObject(with: data!) as? [String: Any],


### PR DESCRIPTION
close #3 

この件はもしかしたら不具合ではなく仕様かもしれません。ただ、検索を実行した後にキーボードが閉じないため検索結果を見られる領域が狭くて気になったので修正してみました。気づいた不具合らしき挙動はこの PR まですべて修正したので #3 は閉じます。

| before | after |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 - 2022-03-14 at 23 15 06](https://user-images.githubusercontent.com/22269397/158191359-f2001467-3007-40f6-8f68-9cc7aec173ed.png) | ![Simulator Screen Shot - iPhone 13 - 2022-03-14 at 23 15 45](https://user-images.githubusercontent.com/22269397/158191402-dcdb23ee-d97a-42e0-abaf-c9f226f29b4c.png) |