### PR TITLE
SearchBar の説明文言を入力テキストではなく placeholder として実装する

### DIFF
--- a/iOSEngineerCodeCheck/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/RepositorySearchViewController.swift
@@ -53,9 +53,9 @@ class RepositorySearchViewController: UITableViewController {
         selectedIndex = indexPath.row
         performSegue(withIdentifier: "Detail", sender: self)
     }
-    
+
     private func setupSearchBar() {
-        searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
+        searchBar.placeholder = "Search..."
         searchBar.delegate = self
     }
 


### PR DESCRIPTION
ref: #3 

SearchBar のテキストフィールドの `GitHubのリポジトリを検索できるよー` という文言が入力テキストとして実装されていたため、

- 最初からテキストフィールドが入力されている見慣れない UI にユーザが戸惑う可能性がある
- タップ時にテキストをクリアする処理を入れる必要があり複雑になっている
- タップ後に再びテキストフィールドが空になっても元の説明文言が表示されない

などの問題がありました。素直に placeholder として実装するように修正しました。

また、アプリ内でここだけ文言が日本語だったので周囲に合わせて英語に変更しました。