### PR TITLE
レポジトリ検索画面に適切なタイトルを設定する

### DIFF
--- a/iOSEngineerCodeCheck/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/RepositorySearchViewController.swift
@@ -20,6 +20,7 @@ class RepositorySearchViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        setupNavigationBar()
         setupSearchBar()
         setupTableView()
     }
@@ -52,6 +53,10 @@ class RepositorySearchViewController: UITableViewController {
         // selectedIndex は画面遷移先で使われるので遷移前に値を設定しておく必要がある
         selectedIndex = indexPath.row
         performSegue(withIdentifier: "Detail", sender: self)
+    }
+
+    private func setupNavigationBar() {
+        title = "Search Repositories"
     }
 
     private func setupSearchBar() {


### PR DESCRIPTION
close #3 

レポジトリ検索画面にタイトルが設定されていないため、`Root View Controller` というユーザから見たらアプリに関係ない文言が NavigationBar に表示されていました。適切と思われるタイトルを設定することによりこの問題を修正します。

| before | after |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 - 2022-03-14 at 23 43 47](https://user-images.githubusercontent.com/22269397/158196859-c0d5dfaa-4311-4cbc-8490-8348846c7a8d.png) | ![Simulator Screen Shot - iPhone 13 - 2022-03-14 at 23 45 32](https://user-images.githubusercontent.com/22269397/158196886-4af6f541-dd33-4b93-a40d-c1780fa5d107.png) |