### PR TITLE
不要な force unwrap をしないようにする

### DIFF
--- a/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
@@ -21,7 +21,7 @@ class RepositoryDetailViewController: UIViewController {
     @IBOutlet weak private var forksLabel: UILabel!
     @IBOutlet weak private var openIssuesLabel: UILabel!
 
-    private let repository: [String: Any]!
+    private let repository: [String: Any]
 
     init?(coder: NSCoder, repository: [String: Any]) {
         self.repository = repository
@@ -50,13 +50,18 @@ class RepositoryDetailViewController: UIViewController {
 
     func setupAvatarImage(repository: [String: Any]) {
         guard let owner = repository["owner"] as? [String: Any],
-            let avatarURL = owner["avatar_url"] as? String
+            let avatarURLString = owner["avatar_url"] as? String,
+            let avatarURL = URL(string: avatarURLString)
         else {
             return
         }
 
-        URLSession.shared.dataTask(with: URL(string: avatarURL)!) { (data, res, err) in
-            let image = UIImage(data: data!)!
+        URLSession.shared.dataTask(with: avatarURL) { (data, res, err) in
+            guard let data = data,
+                let image = UIImage(data: data)
+            else {
+                return
+            }
             DispatchQueue.main.async {
                 self.avatarImageView.image = image
             }

--- a/iOSEngineerCodeCheck/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/RepositorySearchViewController.swift
@@ -71,14 +71,17 @@ extension RepositorySearchViewController: UISearchBarDelegate {
     }
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        let query = searchBar.text!
+        let query = searchBar.text ?? ""
         guard !query.isEmpty else { return }
 
         searchBar.resignFirstResponder()
 
-        let url = "https://api.github.com/search/repositories?q=\(query)"
-        task = URLSession.shared.dataTask(with: URL(string: url)!) { (data, res, err) in
-            guard let obj = try! JSONSerialization.jsonObject(with: data!) as? [String: Any],
+        guard let url = URL(string: "https://api.github.com/search/repositories?q=\(query)") else {
+            return
+        }
+        task = URLSession.shared.dataTask(with: url) { (data, res, err) in
+            guard let data = data,
+                let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                 let items = obj["items"] as? [[String: Any]]
             else {
                 return


### PR DESCRIPTION
close #2 

いくつかの force unwrap をやめます。場面によっては force unwrap により開発時にクラッシュさせて問題を気づきやすくした方が良いですが、今回の修正範囲にはそのようなものは含まないようにしています。また、本来は force unwrap をやめたら、それまで force unwrap していたケースについてのエラーハンドリング（Alert を表示するなど）を追加すべきですが、範囲が大きすぎるのとアプリの仕様変更になってしまうので別の issue でやろうと思います -> https://github.com/maiyama18/ios-engineer-codecheck/issues/26 。