### PR TITLE
検索して詳細画面に遷移する流れの UI テストを追加する

### DIFF
--- a/iOSEngineerCodeCheck/Views/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryDetail/RepositoryDetailViewController.swift
@@ -14,7 +14,11 @@ class RepositoryDetailViewController: UIViewController {
 
     @IBOutlet weak private var avatarImageView: UIImageView!
 
-    @IBOutlet weak private var titleLabel: UILabel!
+    @IBOutlet weak private var titleLabel: UILabel! {
+        didSet {
+            titleLabel.accessibilityLabel = "DetailTitleLabel"
+        }
+    }
 
     @IBOutlet weak private var languageLabel: UILabel!
 

--- a/iOSEngineerCodeCheck/Views/RepositorySearch/SubtitleTableViewCell.swift
+++ b/iOSEngineerCodeCheck/Views/RepositorySearch/SubtitleTableViewCell.swift
@@ -11,6 +11,8 @@ import UIKit
 class SubtitleTableViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+
+        self.accessibilityIdentifier = "SubtitleCell"
     }
 
     required init?(coder: NSCoder) {

--- a/iOSEngineerCodeCheckUITests/iOSEngineerCodeCheckUITests.swift
+++ b/iOSEngineerCodeCheckUITests/iOSEngineerCodeCheckUITests.swift
@@ -9,35 +9,20 @@
 import XCTest
 
 class iOSEngineerCodeCheckUITests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // UI tests must launch the application that they test.
+    func testSearchAndNavigateToDetail() throws {
         let app = XCUIApplication()
         app.launch()
 
-        // Use recording to get started writing UI tests.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
+        let searchField = app.searchFields["Search..."]
+        searchField.tap()
+        searchField.typeText("swift\n")
 
-    func testLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
-        }
+        XCTAssertTrue(app.cells["SubtitleCell"].waitForExistence(timeout: 3))
+        let cells = app.cells.matching(identifier: "SubtitleCell")
+        XCTAssertEqual(cells.count, 30)
+
+        cells.element(boundBy: 0).tap()
+
+        XCTAssertTrue(app.staticTexts["DetailTitleLabel"].waitForExistence(timeout: 3))
     }
 }


### PR DESCRIPTION
ref: #9 

アプリの最も基本的なユースケースである、特定のワードでレポジトリ検索して結果を見る -> 好きなレポジトリをタップする -> 詳細情報を見る、という流れの UI テストを追加しました。

現在の UI テストの問題点として実際の GitHub API に依存してしまっている点があります。テストの安定性の観点からは、ローカルサーバを立ててそちらを見るようにするか、URLSession を差し替えてレスポンスをモックする方が望ましいので余裕があったら検討します。