### PR TITLE
ViewController に SwiftUI.View を表示するためのメソッドを追加する

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		38EC92A027E15E7D0077BD1F /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EC929F27E15E7D0077BD1F /* String+Extension.swift */; };
 		38EC92A427E16DEF0077BD1F /* Repository+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EC92A327E16DEF0077BD1F /* Repository+Extension.swift */; };
 		38EC92A827E1D2E00077BD1F /* RepositoryDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EC92A727E1D2E00077BD1F /* RepositoryDetailViewModelTests.swift */; };
+		38EC92AA27E20DD80077BD1F /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EC92A927E20DD80077BD1F /* UIViewController+Extension.swift */; };
+		38EC92AC27E20E070077BD1F /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EC92AB27E20E070077BD1F /* UIView+Extension.swift */; };
 		BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -120,6 +122,8 @@
 		38EC929F27E15E7D0077BD1F /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		38EC92A327E16DEF0077BD1F /* Repository+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Repository+Extension.swift"; sourceTree = "<group>"; };
 		38EC92A727E1D2E00077BD1F /* RepositoryDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewModelTests.swift; sourceTree = "<group>"; };
+		38EC92A927E20DD80077BD1F /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
+		38EC92AB27E20E070077BD1F /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -211,6 +215,8 @@
 			isa = PBXGroup;
 			children = (
 				38EC928427E0460E0077BD1F /* Collection+Extension.swift */,
+				38EC92A927E20DD80077BD1F /* UIViewController+Extension.swift */,
+				38EC92AB27E20E070077BD1F /* UIView+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -606,11 +612,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				38EC92AA27E20DD80077BD1F /* UIViewController+Extension.swift in Sources */,
 				BFD945E3244DC5E80012785A /* RepositorySearchViewController.swift in Sources */,
 				38EC928927E04C350077BD1F /* RepositoryDetailRouting.swift in Sources */,
 				38EC928527E0460E0077BD1F /* Collection+Extension.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
 				38EC925027DF807C0077BD1F /* SubtitleTableViewCell.swift in Sources */,
+				38EC92AC27E20E070077BD1F /* UIView+Extension.swift in Sources */,
 				38EC928227E043760077BD1F /* RepositorySearchViewModel.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,

--- a/iOSEngineerCodeCheck/Extensions/UIView+Extension.swift
+++ b/iOSEngineerCodeCheck/Extensions/UIView+Extension.swift
@@ -1,0 +1,25 @@
+//
+//  UIView+Extension.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by maiyama on 2022/03/16.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    func pinEdgesToSuperView() {
+        guard let view = superview else {
+            return
+        }
+
+        translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            topAnchor.constraint(equalTo: view.topAnchor),
+            leftAnchor.constraint(equalTo: view.leftAnchor),
+            rightAnchor.constraint(equalTo: view.rightAnchor),
+            bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+}

--- a/iOSEngineerCodeCheck/Extensions/UIViewController+Extension.swift
+++ b/iOSEngineerCodeCheck/Extensions/UIViewController+Extension.swift
@@ -1,0 +1,20 @@
+//
+//  UIViewController+Extension.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by maiyama on 2022/03/16.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import SwiftUI
+
+extension UIViewController {
+    public func hostSwiftUIView<Content: View>(_ rootView: Content) {
+        let hostingVC = UIHostingController(rootView: rootView)
+        addChild(hostingVC)
+        hostingVC.didMove(toParent: self)
+        view.addSubview(hostingVC.view)
+        hostingVC.view.translatesAutoresizingMaskIntoConstraints = false
+        hostingVC.view.pinEdgesToSuperView()
+    }
+}


### PR DESCRIPTION
ref: #7 

https://github.com/maiyama18/ios-engineer-codecheck/issues/7#issuecomment-1069074884 にコメントしたように、 UI をいい感じにしつつ画面は SwiftUI で置き換えていこうと思います。事前にそのための便利メソッドを追加しておきます。ViewController で

```
hostSwiftUIView(Text("Hello")
```

のような感じで呼び出すと SwiftUI.View を表示できます。