### PR TITLE
検索履歴に同じクエリが重複しないようにする

### DIFF
--- a/GitHub/GitHubClient.swift
+++ b/GitHub/GitHubClient.swift
@@ -127,8 +127,9 @@ public final class GitHubClient: GitHubClientProtocol {
     }
 
     private func addToSearchHistory(query: String) {
-        let currentHistory = userDefaults.searchHistory
-        // 最新の検索履歴を最大100件まで保持する
+        // 同じクエリが重複しないように追加前に filter しておく
+        let currentHistory = userDefaults.searchHistory.filter { $0 != query }
+        // 最新の検索履歴を最大 `searchHistoryCapacity` 件まで保持する
         userDefaults.searchHistory = Array(([query] + currentHistory).prefix(searchHistoryCapacity))
     }
 }

--- a/GitHubTests/GitHubClientTests.swift
+++ b/GitHubTests/GitHubClientTests.swift
@@ -133,13 +133,26 @@ class GitHubClientTests: XCTestCase {
         try setUpMockSession(
             responseFileName: "search_success", statusCode: 200, rateLimitRemaining: 9)
 
-        let _ = try await client.search(query: "query", sortOrder: .bestMatch, page: 1)
         for i in 1...101 {
             let _ = try await client.search(query: "query \(i)", sortOrder: .bestMatch, page: 1)
         }
         XCTAssertEqual(
             client.getSearchHistory(maxCount: -1),
             []
+        )
+    }
+
+    func testSearchHistoryNodDuplicated() async throws {
+        try setUpMockSession(
+            responseFileName: "search_success", statusCode: 200, rateLimitRemaining: 9)
+
+        for i in 1...3 {
+            let _ = try await client.search(query: "query \(i)", sortOrder: .bestMatch, page: 1)
+        }
+        let _ = try await client.search(query: "query 2", sortOrder: .bestMatch, page: 1)
+        XCTAssertEqual(
+            client.getSearchHistory(maxCount: 5),
+            [2, 3, 1].map { "query \($0)" }
         )
     }
 


### PR DESCRIPTION
close #40 

これまでは `Swift` というクエリで３回連続検索した時に検索履歴に `Swift` が３個並んでいましたが、使いづらいし不自然なので同じクエリは必ず１個だけしか表示されないようにしました。これで検索履歴周りはとりあえずできたと思っているので issue は close します。

![fix-history](https://user-images.githubusercontent.com/22269397/159146526-11175e1b-369c-4d5f-8d6f-b7b99fd8ba01.gif)