### PR TITLE
検索のリクエストが一瞬で終わる場合に HUD がちらつかないようにする

### DIFF
--- a/iOSEngineerCodeCheck/AppDelegate.swift
+++ b/iOSEngineerCodeCheck/AppDelegate.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 YUMEMI Inc. All rights reserved.
 //
 
+import PKHUD
 import UIKit
 
 @UIApplicationMain
@@ -15,6 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        PKHUD.sharedHUD.gracePeriod = 0.2
         return true
     }
 


### PR DESCRIPTION
gif だと伝わりにくいのですが、前回と同じクエリで検索する場合など検索リクエストが一瞬で終わると HUD が一瞬だけ表示されてチラつくのでこれを修正しました。 PKHUD の `gracePeriod` というプロパティを設定すると、その秒数だけ表示を待ってくれるので `gracePeriod` 以下の時間で HUD の表示が終わるような場合に HUD が全く表示されなくなります。

| before | after |
| --- | --- |
| ![flicker-before](https://user-images.githubusercontent.com/22269397/159147420-d2dfbce8-ba11-42cc-872a-a97c8a21ebf0.gif) | ![flicker-after](https://user-images.githubusercontent.com/22269397/159147425-9732d768-a83b-44e7-93c9-6ae5b4a7e26b.gif) |