### PR TITLE
ScrollView の上端に達したときに画面がかくつく問題を修正する

### DIFF
--- a/iOSEngineerCodeCheck/Screens/RepositorySearch/Views/RepositorySearchResultsSection.swift
+++ b/iOSEngineerCodeCheck/Screens/RepositorySearch/Views/RepositorySearchResultsSection.swift
@@ -20,11 +20,11 @@ struct RepositorySearchResultsSection: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView(showsIndicators: false) {
-                LazyVStack {
-                    Color.clear
-                        .frame(width: 0, height: 0, alignment: .top)
-                        .id(topViewID)
+                Color.clear
+                    .frame(width: 0, height: 0, alignment: .top)
+                    .id(topViewID)
 
+                LazyVStack {
                     ForEach(repositories, id: \.fullName) { repository in
                         VStack {
                             RepositoryListItemView(


### PR DESCRIPTION
タイトル＆下に貼った gif の通りです。正確な原因がまだわかっていないのですが、どうやら余計な View が LazyVStack の中にあると発生するようなので外に出しました。

| before | after |
| --- | --- |
| ![scroll-before](https://user-images.githubusercontent.com/22269397/159148065-85baa814-3c04-4fbe-8682-cbd52e310ea4.gif) |  ![scroll-after](https://user-images.githubusercontent.com/22269397/159148074-8ed7782c-5826-4674-91b3-9f2ddd352566.gif) |